### PR TITLE
Detection of an exception on a before hook

### DIFF
--- a/lib/rspec-steps.rb
+++ b/lib/rspec-steps.rb
@@ -1,2 +1,3 @@
 require 'rspec-steps/duckpunch/object-extensions'
 require 'rspec-steps/duckpunch/example-group'
+require 'rspec-steps/duckpunch/example'

--- a/lib/rspec-steps/duckpunch/example.rb
+++ b/lib/rspec-steps/duckpunch/example.rb
@@ -1,0 +1,5 @@
+RSpec::Core::Example.class_eval do
+  def exception
+    @exception
+  end
+end

--- a/lib/rspec-steps/stepwise.rb
+++ b/lib/rspec-steps/stepwise.rb
@@ -112,6 +112,12 @@ module RSpecStepwise
       suspend_transactional_fixtures do
         whole_list_example.run(instance, reporter)
       end
+
+      unless whole_list_example.exception.nil?
+        RSpec.wants_to_quit = true if fail_fast?
+        fail_filtered_examples(whole_list_example.exception, reporter)
+      end
+
     end
   end
 

--- a/spec/example_group_spec.rb
+++ b/spec/example_group_spec.rb
@@ -29,6 +29,25 @@ describe RSpec::Core::ExampleGroup, "defined as stepwise" do
       end
     end
 
+    it "should mark later examples as failed if a before hook fails" do
+      group = nil
+      exception = Exception.new "Testing Error"
+
+      sandboxed do
+        group = steps "Test Steps" do
+          before { raise exception }
+          it { 1.should == 1 }
+          it { 1.should == 1 }
+        end
+        group.run
+      end
+
+      group.examples.each do |example|
+        example.metadata[:execution_result][:status].should == 'failed'
+        example.metadata[:execution_result][:exception].should == exception
+      end
+    end
+
     it "should mark later examples as pending if one fails" do
       group = nil
       sandboxed do


### PR DESCRIPTION
As reported in #10 when a before hook raises an exception the specs doesn't fail and making extremely difficult to find those errors when you are running the whole spec suite.

I just add an accessor to the exception of a example and then check if the whole list example have any exception, in which case we make all the examples fail
