### PR TITLE
Fix shared_steps in DSL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-steps (2.1.1)
+    rspec-steps (2.1.2)
       rspec (>= 3.0, < 3.99)
 
 GEM

--- a/gemfiles/3.0.lock
+++ b/gemfiles/3.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-steps (2.1.1)
+    rspec-steps (2.1.2)
       rspec (>= 3.0, < 3.99)
 
 GEM

--- a/gemfiles/3.1.lock
+++ b/gemfiles/3.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-steps (2.1.1)
+    rspec-steps (2.1.2)
       rspec (>= 3.0, < 3.99)
 
 GEM

--- a/gemfiles/3.2.lock
+++ b/gemfiles/3.2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-steps (2.1.1)
+    rspec-steps (2.1.2)
       rspec (>= 3.0, < 3.99)
 
 GEM

--- a/gemfiles/3.3.lock
+++ b/gemfiles/3.3.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-steps (2.1.1)
+    rspec-steps (2.1.2)
       rspec (>= 3.0, < 3.99)
 
 GEM

--- a/lib/rspec-steps/dsl.rb
+++ b/lib/rspec-steps/dsl.rb
@@ -23,7 +23,7 @@ module RSpec::Steps
       name = args.first
       raise "shared step lists need a String for a name" unless name.is_a? String
       raise "there is already a step list named #{name}" if SharedSteps.has_key?(name)
-      SharedSteps[name] = Describer.new(*args, {:caller => caller}, &block)
+      SharedSteps[name] = Describer.new(args, {:caller => caller}, &block)
     end
   end
   extend DSL

--- a/rspec-steps.gemspec
+++ b/rspec-steps.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name		= "rspec-steps"
-  spec.version		= "2.1.1"
+  spec.version		= "2.1.2"
   author_list = {
     "Judson Lester" => "judson@lrdesign.com",
     "Evan Dorn" => "evan@lrdesign.com"


### PR DESCRIPTION
There was mistake in shared_steps method. The `*` caused that `Describer` throw an error `undefined method 'last' for "some string":String` when try do this `if @group_args.last.is_a? Hash`